### PR TITLE
fix  bugs in check cache

### DIFF
--- a/dependency/BrocObject.py
+++ b/dependency/BrocObject.py
@@ -54,7 +54,8 @@ class BrocObject(object):
                     self.modify_time = os.stat(self.pathname.st_mtime) 
             except BaseException:
                 pass
-        self.build = True             # build flag, if build is True, the BrocObject need to compiled
+        self.build = True              # build flag, if build is True, the BrocObject need to compiled
+        self.modified = False          # to mark whether the file has been modified since last build
 
     def __eq__(self, other):
         """
@@ -179,6 +180,12 @@ class BrocObject(object):
         '''
         return self.build
 
+    def Modified(self):
+        '''
+        return modified flag
+        '''
+        return self.modified
+
     def IsBuilt(self):
         """
         check whether BrocObject has been built already
@@ -217,12 +224,11 @@ class BrocObject(object):
         ret, msg = Function.RunCommand(self.build_cmd, ignore_stderr_when_ok = False)
         if ret != 0:
             result['ret'] = False
-            result['msg'] = "%s\n%s" % (str(self.build_cmd), msg)
         else:
             self.build = False
             result['ret'] = True
-            #TODO handle decode type of msg
-            result['msg'] = msg
+
+        result['msg'] = msg
         return result
 
     def NotifyReverseDeps(self):
@@ -230,8 +236,7 @@ class BrocObject(object):
         to notify all reversed dependent BrocObject objects to build
         """
         for obj in self.reverse_deps:
-            #Log.Log().LevPrint("MSG", "%s nofity reverse cache dep(%s) build" \
-#% (self.pathname, obj.Pathname()))
+            #Log.Log().LevPrint("MSG", "%s nofity reverse cache dep(%s) build" % (self.pathname, obj.Pathname()))
             obj.EnableBuild()
 
     def IsChanged(self, target=None):
@@ -271,7 +276,7 @@ class BrocObject(object):
                 ret = True
             return ret
 
-    def IsSelfChanged(self):
+    def IsModified(self):
         '''
         to check whether object self changed
         Returns:
@@ -318,6 +323,7 @@ class BrocObject(object):
             return 
 
         if self.modify_time == modify_time:
+            self.modified = False
             self.build = False
             return 
         
@@ -326,6 +332,7 @@ class BrocObject(object):
         _hash = Function.GetFileHash(self.pathname)
         # Log.Log().LevPrint("MSG", "update %s hash id(%s) %s --> %s" % (self.pathname, id(self), self.hash, _hash))
         self.hash = _hash 
+        self.modified = False
         self.build = False
 
     def DisableBuild(self):
@@ -333,6 +340,12 @@ class BrocObject(object):
         disable build flag
         """
         self.build = False
+
+    def DisableModified(self):
+        """
+        disable modify flag
+        """
+        self.modified = False
 
 
 class HeaderCache(BrocObject):
@@ -390,7 +403,7 @@ class SourceCache(BrocObject):
 
         return False
 
-    def IsSelfChanged(self):
+    def IsModified(self):
         '''
         to check whether source file and obj file changed
         Returns:
@@ -399,13 +412,13 @@ class SourceCache(BrocObject):
             -1: the source file is missing
         '''
         # check source file itself
-        ret = self.src_obj.IsSelfChanged()
+        ret = self.src_obj.IsModified()
         # source file changed or missed
         if ret != 0:
             return ret
         # source file not change, to check object file
         else:
-            ret = BrocObject.IsSelfChanged(self)
+            ret = BrocObject.IsModified(self)
             return 0 if ret == 0 else 1
 
     def Update(self):

--- a/dependency/BrocObjectMaster.py
+++ b/dependency/BrocObjectMaster.py
@@ -165,14 +165,14 @@ class BrocObjectMaster(threading.Thread):
                 source_cache.EnableBuild()
             
         last_headers = set(map(lambda x: x.Pathname(), source_cache.Deps()))
-        now_headers = source.builder.GetHeaderFiles()
+        now_headers = source.GetHeaderFiles()
         missing_headers = last_headers - now_headers
         for f in missing_headers:
             source_cache.DelDep(f)
             self._cache[f].DelReverseDep(source_cache.Pathname())
         # check head files source object depended
         ret = False
-        for f in source.builder.GetHeaderFiles():
+        for f in source.GetHeaderFiles():
             if self._check_head_cache(f, source_cache):
                 ret = True
 
@@ -291,7 +291,7 @@ class BrocObjectMaster(threading.Thread):
         target_cache.AddDep(source_cache)
 
         # add header cache for source cache
-        header_files = source.builder.GetHeaderFiles()
+        header_files = source.GetHeaderFiles()
         for f in header_files:
             if f in self._cache:
                 source_cache.AddDep(self._cache[f])

--- a/dependency/BrocTree.py
+++ b/dependency/BrocTree.py
@@ -174,6 +174,7 @@ class BrocTree(object):
         Raises:
             if handle node failed, raise BrocTreeError
         """
+        # self._logger.LevPrint("MSG", "handle node(%s) ..." % node.module.name)
         # if node.module.url has been handled in other module's BROC
         # Key is module's cvspath + branch kind + tag name or branch name.
         # Key can't be module's url because ,in git any branch or tag has a same url.
@@ -188,6 +189,7 @@ class BrocTree(object):
 
         try:
             # to fetch BROC file
+            # self._logger.LevPrint("MSG", "fetch node(%s) BROC" % node.module.name)
             broc_path = self._check_broc(node)
             if broc_path is None:
                 self._logger.LevPrint("ERROR", "fetch BROC failed")
@@ -237,7 +239,6 @@ class BrocTree(object):
                 if node.module.is_main:
                     return os.path.join(_broc_dir, "BROC")
 
-                #cmd = "cd %s && git fetch --all" % _broc_dir
                 cmd = "cd %s " % _broc_dir
                 if node.module.tag_name:
                     cmd += " && (git checkout %s || (git fetch --all && git checkout %s))" \
@@ -246,6 +247,7 @@ class BrocTree(object):
                     cmd += " && (git checkout %s || (git fetch --all && git checkout %s))" \
 % (node.module.br_name, node.module.br_name)
                 # to run cmd
+                # self._logger.LevPrint("MSG", "run cmd: %s ..." % cmd)
                 ret, msg = Function.RunCommand(cmd)
                 if ret != 0:
                     self._logger.LevPrint("ERROR", "fail to find BROC(%s) failed(%s)" % (cmd, msg))

--- a/dependency/Builder.py
+++ b/dependency/Builder.py
@@ -75,7 +75,6 @@ class ObjBuilder(Builder):
         self._opts = None
         self._infile = infile
         self._header_cmd = None
-        self._header_files = set()
         if includes:
             self._includes += "\t".join(map(lambda x: "-I%s \\\n" % os.path.normpath(x), includes))
         if opts: 
@@ -91,11 +90,12 @@ class ObjBuilder(Builder):
         """
         calculate the header files that source file dependends
         Returns:
-            { ret : True | False, msg : 'error message' }
+            { ret : True | False, headers : set(), msg : 'error message' }
             calculate successfully ret is True; otherwise ret is False and msg contains error message
         """
         result = dict()
         result['ret'] = False
+        result['headers'] = set()
         result['msg'] = ''
         retcode, msg = Function.RunCommand(self._header_cmd, ignore_stderr_when_ok=True)
         if retcode != 0:
@@ -106,9 +106,9 @@ class ObjBuilder(Builder):
         for f in files:
             if f.endswith(".h"):
                 if self.workspace in f:
-                    self._header_files.add(f[len(self.workspace)+1:])
+                    result['headers'].add(f[len(self.workspace)+1:])
                 else:
-                    self._header_files.add(f)
+                    result['headers'].add(f)
         result['ret'] = True
         return result
 
@@ -117,15 +117,6 @@ class ObjBuilder(Builder):
         return cmd for caculating header files
         """
         return self._header_cmd
-
-    def GetHeaderFiles(self):
-        """
-        return the header files
-        Returns:
-            return a list containing header files
-        """
-        return self._header_files
-
 
 class LibBuilder(Builder):
     """

--- a/dependency/Source.py
+++ b/dependency/Source.py
@@ -104,6 +104,12 @@ class Source(object):
         """
         return self.headers
 
+    def SetHeaderFiles(self, headers):
+        """
+        set headers files
+        """
+        self.headers = headers
+
     def Compiler(self):
         """
         return the compiler cmd

--- a/dependency/Source.py
+++ b/dependency/Source.py
@@ -78,6 +78,7 @@ class Source(object):
 
         # builder
         self.builder = None 
+        self.headers = set()                      # the head files
 
     def __eq__(self, v):
         """
@@ -90,6 +91,18 @@ class Source(object):
         return build cmd
         """
         return self.builder.GetBuildCmd()
+
+    def GetHeaderCmd(self):
+        """
+        return cmd for caulating head files
+        """
+        return self.builder.GetHeaderCmd()
+
+    def GetHeaderFiles(self):
+        """
+        return the list of head files
+        """
+        return self.headers
 
     def Compiler(self):
         """
@@ -178,6 +191,23 @@ class Source(object):
         if not cflags_flag:
             self.cflags = self.env.CFlags().V()
 
+    def CalcHeaderFiles(self):
+        """
+        calculate head file 
+        Returns:
+            True if caculate successfully
+            False if failed to caculate
+        """
+        ret = True
+        res = self.builder.CalcHeaderFiles()
+        if not res['ret']:
+            ret = False
+        else:
+            self.headers = res['headers']
+            
+        return ret
+
+
 class CSource(Source):
     """
     C Source Code
@@ -206,11 +236,7 @@ class CSource(Source):
         self.builder = Builder.ObjBuilder(self.outfile, self.infile, self.includes, 
                                           options, self.env.CC(), self.env.Workspace())
 
-    def CalcHeaderFiles(self):
-        """
-        calculate head file 
-        """
-        self.builder.CalcHeaderFiles()
+
 
 class CXXSource(Source):
     """
@@ -239,8 +265,3 @@ class CXXSource(Source):
         options.extend(self.cppflags + self.cxxflags)
         self.builder = Builder.ObjBuilder(self.outfile, self.infile, self.includes, 
                                           options, self.env.CXX(), self.env.Workspace())
-    def CalcHeaderFiles(self):
-        """
-        calculate head file 
-        """
-        self.builder.CalcHeaderFiles()

--- a/unittest/test_Builder.py
+++ b/unittest/test_Builder.py
@@ -118,7 +118,7 @@ int main()\n\
 }\n")
         ret = builder.CalcHeaderFiles()
         self.assertEqual(True, ret['ret'])
-        self.assertEqual(sorted(["hello.h", 'world.h']), sorted(builder.GetHeaderFiles()))
+        self.assertEqual(sorted(["hello.h", 'world.h']), sorted(ret['headers']))
 
         Function.DelFiles('get_header_files.cpp')
         Function.DelFiles('hello.h')


### PR DESCRIPTION
在判断头文件的时候，如果source对象没有重新计算过，会删掉该 sources对象缓存中的依赖的头文件
