### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ https://github.com/baidu/broc/wiki/broc-tutorial
 # 构建规范
 https://github.com/baidu/broc/wiki/broc-manual
 
-#反馈与技术支持
+# 反馈与技术支持
 请联系buildcloud@baidu.com
 
-#欢迎加入
+# 欢迎加入
 如果你热爱开源，对我们感兴趣，我们来聊聊吧 buildcloud@baidu.com
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
